### PR TITLE
Add anchor for "Start A LUG" and go to it

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -13,7 +13,7 @@ This site was the original idea of Mark Lewis and it was created in 1997, when h
 1. To provide an initial point for Linux users and non-users to search for LUGs in a specific area.<br><br>The [UK LUG list](/lugs) shows where groups currently are and how they can be contacted.<br><br>LUGs are a local community of Linux users of all levels that gather to share a broad spectrum of Linux information. Both novice and experienced Linux users will find LUGs a useful arena to debate and enquire personal experiences of Linux and indeed, pose those questions they need answering.
 2. To provide resources to freely allow LUGMasters to setup their own local Linux User Group, with our aid, using the lug.org.uk domain name.
 
-<h2>How to start a LUG</h2>
+<a name="start_a_lug"><h2>How to start a LUG</h2>
 
 Before you create a LUG, there are a number of things you should consider:
 
@@ -33,7 +33,7 @@ Once you've decided on a name and coverage area for your LUG, you should:
   * Advise the UK Linux Magazines (for example, 'Linux Format' and 'Linux Magazine') of your new LUG details for publication
   * Maybe on other local LUG mailing lists (with permission of course)
   * Enjoy your new LUG, and have fun
-
+</a>
 Other resources:
 
 * Rick Moen's [User Group HOWTO](http://www.tldp.org/HOWTO/User-Group-HOWTO.html).

--- a/apply/index.md
+++ b/apply/index.md
@@ -16,4 +16,4 @@ To apply for lug.org.uk resources, you need to contact the [admin mailing list](
     * Hosted DNS records (e.g. We will host A, AAAA, CNAME, TXT, MX or NS records for foo.lug.org.uk)
   * Mailing list (via [mailman.lug.org.uk](https://mailman.lug.org.uk/mailman/listinfo/) )
 
-Before applying, please ensure that you have read [How to start a LUG](/about/) on our about page, and you have checked the [LUGs list](/lugs) to ensure there are no other LUGs close to you.
+Before applying, please ensure that you have read [How to start a LUG](/about/#start_a_lug) on our about page, and you have checked the [LUGs list](/lugs) to ensure there are no other LUGs close to you.


### PR DESCRIPTION
Added an HTML anchor on the "Start A LUG" section of the About page and set the link on the Apply page to use it.